### PR TITLE
Use a string for first parameter in `add_submenu_page()`

### DIFF
--- a/includes/vendor/rocketgeek-tools/class-rocketgeek-onboarding.php
+++ b/includes/vendor/rocketgeek-tools/class-rocketgeek-onboarding.php
@@ -55,8 +55,8 @@ class RocketGeek_Onboarding_Beta {
         $rgut = new RocketGeek_Satellite_Beta( $slug, $product_file, 'update', 'plugin' );
     }
     
-    public function admin_menu () {
-        add_submenu_page( null, $this->page_title, $this->menu_title, $this->capability, $this->menu_slug, array( $this, 'do_options_page' ) );
+    public function admin_menu() {
+        add_submenu_page( '', $this->page_title, $this->menu_title, $this->capability, $this->menu_slug, array( $this, 'do_options_page' ) );
     }
     
     public function do_options_page() {


### PR DESCRIPTION
Avoid deprecation notices in PHP 8.1+ by using the correct type. The first five parameters for `add_submenu_page()` should all be strings.

```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /.../wp-includes/functions.php on line 7241
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /.../wp-includes/functions.php on line 2187
```

[Deepak Rajpal](https://developer.wordpress.org/reference/functions/add_submenu_page/#comment-6446) suggested simply replacing `null` with an empty string (or 'options.php'). The empty string removes the errors, but please verify that the function behaves as intended with the change.

See also [Core Trac 57580](https://core.trac.wordpress.org/ticket/57580).